### PR TITLE
Look for _GLIBCXX_IOMANIP

### DIFF
--- a/include/TRACE/trace.h
+++ b/include/TRACE/trace.h
@@ -3955,9 +3955,7 @@ public:
 		T_STREAM_DBG << "TraceStreamer precisionStr is now " << precisionStr << std::endl;
 		return *this;
 	}
-#	if !defined(__clang__) || (defined(__clang__) && __clang_major__ == 3 && __clang_minor__ == 4) \
-	|| \
-		(__clang_major__ >= 10 && __clang_major__ <= 11)
+#	if !defined(__clang__) || defined(_GLIBCXX_IOMANIP)
 
 	template<typename Char_t>
 	inline TraceStreamer &operator<<(std::_Setfill<Char_t> r)


### PR DESCRIPTION
Discovered while trying to build with Clang 17...apparently, clang has the option to include the glib from GCC, leading to similar behavior. Trigger using the GCC-style iomanip functions if the GLIBCXX is used (_GLIBCXX_IOMANIP is defined by the glib implementation of the iomanip header)