### PR TITLE
ignore ups directory -- don't care if it's still there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ obj/*
 rpm/TRACE.tar.bz2
 CMakePresets.json
 *.pyc
-ups/TRACE.table
+ups
 Linux64bit*
 module
 .vscode


### PR DESCRIPTION
I still use the dir in some development cases.