### PR TITLE
Ryan want to force TLVL_INFO (not levels below [bug?])

### DIFF
--- a/include/TRACE/tracemf.h
+++ b/include/TRACE/tracemf.h
@@ -3,7 +3,7 @@
  // or COPYING file. If you do not have such a file, one can be obtained by
  // contacting Ron or Fermi Lab in Batavia IL, 60510, phone: 630-840-3000.
  // $RCSfile: tracemf.hh,v $
- // rev="$Revision: 1702 $$Date: 2025-01-28 12:48:14 -0600 (Tue, 28 Jan 2025) $";
+ // rev="$Revision: 1728 $$Date: 2026-02-18 17:05:55 -0600 (Wed, 18 Feb 2026) $";
  */
 /**
   * \file tracemf.h
@@ -28,9 +28,12 @@
 								 const std::string& msg, ...)
 #	undef TRACE_LOG_FUNCTION
 #	define TRACE_LOG_FUNCTION mftrace_user
-#	undef TSTREAMER_SL_FRC
+#	undef TSTREAMER_SL_FRC		// in case trace.h included previous
+#	ifndef TRACEMF_SL_FRC_LVL
+#		TRACEMF_SL_FRC_LVL TLVL_INFO
+#	endif
 #	define TSTREAMER_SL_FRC(lvl)               \
-		((lvl < static_cast<int>(TLVL_INFO)) || \
+		((lvl <= static_cast<int>(TRACEMF_SL_FRC_LVL)) || \
 		 ((lvl <= static_cast<int>(TLVL_DEBUG)) && DEBUG_FORCED)) /* in these cases, only mf config/thresh rules */
 #	include "TRACE/trace.h"                                      /* TRACE */
 

--- a/include/TRACE/tracemf.h
+++ b/include/TRACE/tracemf.h
@@ -3,7 +3,7 @@
  // or COPYING file. If you do not have such a file, one can be obtained by
  // contacting Ron or Fermi Lab in Batavia IL, 60510, phone: 630-840-3000.
  // $RCSfile: tracemf.hh,v $
- // rev="$Revision: 1728 $$Date: 2026-02-18 17:05:55 -0600 (Wed, 18 Feb 2026) $";
+ // rev="$Revision: 1729 $$Date: 2026-02-18 18:52:14 -0600 (Wed, 18 Feb 2026) $";
  */
 /**
   * \file tracemf.h
@@ -28,11 +28,11 @@
 								 const std::string& msg, ...)
 #	undef TRACE_LOG_FUNCTION
 #	define TRACE_LOG_FUNCTION mftrace_user
-#	undef TSTREAMER_SL_FRC		// in case trace.h included previous
+#	undef TSTREAMER_SL_FRC  // in case trace.h included previous
 #	ifndef TRACEMF_SL_FRC_LVL
 #		TRACEMF_SL_FRC_LVL TLVL_INFO
 #	endif
-#	define TSTREAMER_SL_FRC(lvl)               \
+#	define TSTREAMER_SL_FRC(lvl)                         \
 		((lvl <= static_cast<int>(TRACEMF_SL_FRC_LVL)) || \
 		 ((lvl <= static_cast<int>(TLVL_DEBUG)) && DEBUG_FORCED)) /* in these cases, only mf config/thresh rules */
 #	include "TRACE/trace.h"                                      /* TRACE */


### PR DESCRIPTION
Currently the slow-path force for tracemf.h is messaged up where it is possible to turn off TLVL_INFO, but in some cases not TLVL_DEBUG -- which seems strange.
I think the logic with the pull request is better, but still a bit strange considering the MF threshold configuration. But I
can't immediately think of the perfect solution; so maybe this is just good enough.