### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/artdaq-build-single-pkg.yml
+++ b/.github/workflows/artdaq-build-single-pkg.yml
@@ -1,5 +1,8 @@
 name: Build Single Pkg Workflow
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/artdaq-develop-cpp-ci.yml
+++ b/.github/workflows/artdaq-develop-cpp-ci.yml
@@ -1,5 +1,8 @@
 name: build-develop
 
+permissions:
+  contents: read
+
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
 on:

--- a/.github/workflows/artdaq-format-single-pkg.yml
+++ b/.github/workflows/artdaq-format-single-pkg.yml
@@ -1,5 +1,8 @@
 name: Format Single Pkg Workflow
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/artdaq-test-single-pkg.yml
+++ b/.github/workflows/artdaq-test-single-pkg.yml
@@ -1,5 +1,8 @@
 name: Test Single Pkg Workflow
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/artdaq-tidy-single-pkg.yml
+++ b/.github/workflows/artdaq-tidy-single-pkg.yml
@@ -1,5 +1,8 @@
 name: Tidy Single Pkg Workflow
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,5 +1,8 @@
 name: Auto approve
 
+permissions:
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/git-whitespace.yml
+++ b/.github/workflows/git-whitespace.yml
@@ -1,5 +1,8 @@
 name: Git Whitespace Check Workflow
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/track_new_issues.yml
+++ b/.github/workflows/track_new_issues.yml
@@ -1,4 +1,9 @@
 name: Add issue to project
+
+# Job doesn't use the default GITHUB_TOKEN
+permissions:
+  contents: read
+
 on:
   issues:
     types:

--- a/.github/workflows/track_new_prs.yml
+++ b/.github/workflows/track_new_prs.yml
@@ -1,4 +1,9 @@
 name: Add pull request to project
+
+# Job doesn't use the default GITHUB_TOKEN
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/art-daq/trace/security/code-scanning/24](https://github.com/art-daq/trace/security/code-scanning/24)

In general, to fix this class of issues, you add an explicit `permissions:` section, either at the root of the workflow (applies to all jobs that lack their own `permissions`) or under a specific job. The block should grant only the minimal scopes needed. When in doubt and if the workflow is primarily building/testing code and not modifying repo state, `contents: read` is a reasonable baseline.

For this workflow, the simplest non-breaking change is to define a minimal `permissions:` block at the top level, since there is only one job (`build_against_dev_release`) and it is a reusable workflow call. A conservative, least-privilege starting point is:

```yaml
permissions:
  contents: read
```

This will ensure the `GITHUB_TOKEN` has read access to repository contents for all jobs unless overridden, which is typically sufficient for a CI build that fetches code and possibly artifacts but does not push commits or manage issues. Concretely, in `.github/workflows/artdaq-develop-cpp-ci.yml`, insert the `permissions:` block after the `name:` (line 1) and before the `on:` block (line 5). No imports or additional methods are needed; this is a declarative YAML change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
