### PR TITLE
use args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .svn
 *~
+*.[do]
 .editorconfig
 bin/*
 obj/*

--- a/include/TRACE/trace.h
+++ b/include/TRACE/trace.h
@@ -8,7 +8,7 @@
 #define TRACE_H
 
 #if !defined(__CUDA_ARCH__) && !defined(__ROOTCLING__) /* Allow inclusion into CUDA file (including .cu files) and ROOT parse */
-#	define TRACE_REV "$Revision: 1744 $$Date: 2026-05-07 18:56:09 -0500 (Thu, 07 May 2026) $"
+#	define TRACE_REV "$Revision: 1747 $$Date: 2026-06-05 14:48:15 -0500 (Fri, 05 Jun 2026) $"
 
 // The C++ streamer style macros...............................................
 /*
@@ -331,7 +331,7 @@ enum tlvle_t { TRACE_LVL_ENUM_0_9, TRACE_LVL_ENUM_10_63 };
 #	endif
 
 // clang-format off
-#define TRACE_REVx $_$Revision: 1744 $_$Date: 2026-05-07 18:56:09 -0500 (Thu, 07 May 2026) $
+#define TRACE_REVx $_$Revision: 1747 $_$Date: 2026-06-05 14:48:15 -0500 (Fri, 05 Jun 2026) $
 // Who would ever have an identifier/token that begins with $_$???
 #define $_$Revision  0?0
 #define $_$Date      ,
@@ -4943,7 +4943,7 @@ TraceGuard<Fun> operator+(TraceGuardOnExit, Fun &&fn)
 #	define TRACE_DBG(...)
 #	define TRACE_DBGN(...)
 #	define TRACE_DBGH(...)
-#	define TRACEF(...)
+#	define TRACEF(lvl, ...) if (0) TRACE_STD_STRING_FORMAT(__VA_ARGS__)
 #	define TRACEFN(...)
 #	define TRACEFH(...)
 #endif /* !defined(__CUDA_ARCH__) */

--- a/include/TRACE/trace.h
+++ b/include/TRACE/trace.h
@@ -8,7 +8,7 @@
 #define TRACE_H
 
 #if !defined(__CUDA_ARCH__) && !defined(__ROOTCLING__) /* Allow inclusion into CUDA file (including .cu files) and ROOT parse */
-#	define TRACE_REV "$Revision: 1747 $$Date: 2026-06-05 14:48:15 -0500 (Fri, 05 Jun 2026) $"
+#	define TRACE_REV "$Revision: 1748 $$Date: 2026-06-05 15:12:02 -0500 (Fri, 05 Jun 2026) $"
 
 // The C++ streamer style macros...............................................
 /*
@@ -331,7 +331,7 @@ enum tlvle_t { TRACE_LVL_ENUM_0_9, TRACE_LVL_ENUM_10_63 };
 #	endif
 
 // clang-format off
-#define TRACE_REVx $_$Revision: 1747 $_$Date: 2026-06-05 14:48:15 -0500 (Fri, 05 Jun 2026) $
+#define TRACE_REVx $_$Revision: 1748 $_$Date: 2026-06-05 15:12:02 -0500 (Fri, 05 Jun 2026) $
 // Who would ever have an identifier/token that begins with $_$???
 #define $_$Revision  0?0
 #define $_$Date      ,
@@ -4943,7 +4943,8 @@ TraceGuard<Fun> operator+(TraceGuardOnExit, Fun &&fn)
 #	define TRACE_DBG(...)
 #	define TRACE_DBGN(...)
 #	define TRACE_DBGH(...)
-#	define TRACEF(lvl, ...) if (0) TRACE_STD_STRING_FORMAT(__VA_ARGS__)
+#	define TRACEF(lvl, ...) \
+		if (0) TRACE_STD_STRING_FORMAT(__VA_ARGS__)
 #	define TRACEFN(...)
 #	define TRACEFH(...)
 #endif /* !defined(__CUDA_ARCH__) */


### PR DESCRIPTION
Some .cu source defines args that are only used in TRACEF calls. This silences "defined but not used" warnings.'