### PR TITLE
init tv_use b/c of gcc16 warning

### DIFF
--- a/src_utility/trace_cntl.c
+++ b/src_utility/trace_cntl.c
@@ -1040,7 +1040,7 @@ void traceShow(const char *ospec, int count, int slotStart, int show_opts, int a
 	const char *file= "";
 	int memlen_out_unused __attribute__((__unused__));
 	trace_ptrs_t *t_ptrs, *trace_ptrs_list_start, *t_ptrs_use;
-	struct timeval tv_use, tv2;
+	struct timeval tv_use= {0}, tv2;
 	int32_t off_use;
 	uint32_t name_width= 0;
 	uint32_t num_entries_total;


### PR DESCRIPTION
Pasha was building on Fedora 44 (evidently with new gcc) and encountered a warning.
```
/home/ron/work/tracePrj/trace/src_utility
pts/4 ron@fedora :^) gcc -g -Wall -DDO_THREADS -O2 -I/home/ron/work/tracePrj/trace/include -g -o /home/ron/work/tracePrj/trace/Linux64bit+7.1/bin/trace_cntl trace_cntl.c -lpthread
In function ‘tvcmp’,
    inlined from ‘traceShow’ at trace_cntl.c:1542:10:
trace_cntl.c:984:45: warning: ‘tv_use.tv_usec’ may be used uninitialized [-Wmaybe-uninitialized]
  984 |         uint64_t t1= tvp1->tv_sec * 1000000 + tvp1->tv_usec;
      |                      ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
trace_cntl.c: In function ‘traceShow’:
trace_cntl.c:1043:24: note: ‘tv_use.tv_usec’ was declared here
 1043 |         struct timeval tv_use, tv2;
      |                        ^~~~~~
In function ‘tvcmp’,
    inlined from ‘traceShow’ at trace_cntl.c:1542:10:
trace_cntl.c:984:35: warning: ‘tv_use.tv_sec’ may be used uninitialized [-Wmaybe-uninitialized]
  984 |         uint64_t t1= tvp1->tv_sec * 1000000 + tvp1->tv_usec;
      |                      ~~~~~~~~~~~~~^~~~~~~~~
trace_cntl.c: In function ‘traceShow’:
trace_cntl.c:1043:24: note: ‘tv_use.tv_sec’ was declared here
 1043 |         struct timeval tv_use, tv2;
      |                        ^~~~~~
--2026-08-06_05:35:23_CDT--
```
